### PR TITLE
Add error handler to duplex stream, see #329

### DIFF
--- a/components/devices/class.interface.js
+++ b/components/devices/class.interface.js
@@ -134,6 +134,15 @@ module.exports = class Interface {
                 writable: output
             });
 
+            // when multiple reuqests are done parallal, sometimes a AbortedErr is thrown
+            // see #329 for details
+            // TODO: Check if the upstream is drained, and perform requests in series
+            // As "quick fix" till a solution is found for #312 catch the trown error
+            socket.on("error", (err) => {
+                console.log("Catched error on http.agent.createConnection", err);
+                this.stream.destroy();
+            });
+
             /*
                         [socket, this.stream, input, output].forEach((stream) => {
                             let cleanup = finished(stream, (err) => {


### PR DESCRIPTION
The `iface.httpAgent` throws sometimes a AbortError when requests are done to quickly/parallel.
To catch that, a error handler was added to the underlying duplex stream.