### PR TITLE
Revert "Switched to husky & removed `console.log`"

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,5 +1,0 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
-#npm test
-npm run lint

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,6 @@
         "grunt-contrib-uglify": "^5.0.1",
         "grunt-env": "^1.0.1",
         "grunt-run": "^0.8.1",
-        "husky": "^8.0.0",
         "minimist": "^1.2.6",
         "mocha": "^9.2.2",
         "mocha.parallel": "^0.15.6",
@@ -3942,21 +3941,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-    },
-    "node_modules/husky": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/husky/-/husky-8.0.3.tgz",
-      "integrity": "sha512-+dQSyqPh4x1hlO1swXBiNb2HzTDN1I2IGLQx1GrBuiqFJfoMrnZWwVmatvSiO+Iz8fBUnf+lekwNo4c2LlXItg==",
-      "dev": true,
-      "bin": {
-        "husky": "lib/bin.js"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/typicode"
-      }
     },
     "node_modules/iconv-lite": {
       "version": "0.4.24",
@@ -10180,12 +10164,6 @@
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         }
       }
-    },
-    "husky": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/husky/-/husky-8.0.3.tgz",
-      "integrity": "sha512-+dQSyqPh4x1hlO1swXBiNb2HzTDN1I2IGLQx1GrBuiqFJfoMrnZWwVmatvSiO+Iz8fBUnf+lekwNo4c2LlXItg==",
-      "dev": true
     },
     "iconv-lite": {
       "version": "0.4.24",

--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
     "release": "grunt release",
     "db:export": "mongodump --db OpenHaus --archive=./demo-database.gz",
     "db:import": "mongorestore --db OpenHaus --archive=./demo-database.gz",
-    "publish": "grunt publish",
-    "prepare": "husky install"
+    "postinstall": "scripts/post-install.sh",
+    "publish": "grunt publish"
   },
   "engines": {
     "node": ">=0.16.0"
@@ -55,7 +55,6 @@
     "mocha.parallel": "^0.15.6",
     "newman": "^6.0.0",
     "nodemon": "^3.0.1",
-    "sinon": "^14.0.2",
-    "husky": "^8.0.0"
+    "sinon": "^14.0.2"
   }
 }

--- a/routes/auth-handler.js
+++ b/routes/auth-handler.js
@@ -108,7 +108,7 @@ module.exports = (C_USERS, router) => {
             return;
         }
 
-        //console.log("User request:", req.user, req.authenticated, process.env.API_AUTH_ENABLED, req.ip, req.socket.remoteAddress, req.method, req.url, req.headers);
+        console.log("User request:", req.user, req.authenticated, process.env.API_AUTH_ENABLED, req.ip, req.socket.remoteAddress, req.method, req.url, req.headers);
 
         next();
 


### PR DESCRIPTION
Reverts OpenHausIO/backend#416

Husky breaks in docker & production environment.
`npm install --omit=prod` & https://github.com/OpenHausIO/backend/actions/runs/7546932779/job/20545788095